### PR TITLE
Fix: Add missing learning_subject field to PlannerForm

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,7 +1,8 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField
+from wtforms import StringField, SubmitField, SelectField
 from wtforms.validators import DataRequired
 
 class PlannerForm(FlaskForm):
+    learning_subject = SelectField('Lernfach', validators=[DataRequired()])
     learning_task = StringField('Lernaufgabe', validators=[DataRequired()], render_kw={"placeholder": "Lernaufgabe"})
     submit = SubmitField('Speichern')

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -24,6 +24,7 @@ notification_service = NotificationService()
 @main_bp.route('/', methods=['GET', 'POST'])
 def home():
     form = PlannerForm()
+    form.learning_subject.choices = content_library.get_subjects()
     if form.validate_on_submit():
         try:
             task_manager.add_task(title=form.learning_task.data)


### PR DESCRIPTION
### **User description**
The original code was missing the `learning_subject` field in the `PlannerForm`, which caused a `jinja2.exceptions.UndefinedError` when rendering the `index.html` template.

This commit adds the `learning_subject` field to the `PlannerForm` in `app/main/forms.py` and populates the choices for this field in the `home` route in `app/main/routes.py`. This resolves the error and allows the application to run correctly.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `learning_subject` field to `PlannerForm`

- Populate subject choices from content library

- Fix Jinja2 template rendering error


___

### **Changes diagram**

```mermaid
flowchart LR
  A["PlannerForm"] --> B["Add SelectField"]
  B --> C["Import SelectField"]
  D["home route"] --> E["Populate choices"]
  E --> F["Fix template error"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>forms.py</strong><dd><code>Add learning_subject SelectField to form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main/forms.py

<li>Import <code>SelectField</code> from wtforms<br> <li> Add <code>learning_subject</code> SelectField to PlannerForm with validation


</details>


  </td>
  <td><a href="https://github.com/DaFum/Wochenplan/pull/11/files#diff-a1c8d24b22d4478fe71f75fd43b71b18dd82aae97bc63de84473a6da1902909b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Populate subject choices in home route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main/routes.py

<li>Populate <code>learning_subject</code> choices from content library<br> <li> Set choices before form validation in home route


</details>


  </td>
  <td><a href="https://github.com/DaFum/Wochenplan/pull/11/files#diff-5dc53bb87601833d10c0498756894f6d51854244fa258392f3d325d5680affd0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>