### PR TITLE
Gracefully handle missing content-type for Pollinations images

### DIFF
--- a/pollinations/image.py
+++ b/pollinations/image.py
@@ -89,22 +89,20 @@ class Image:
         response = self._sync_client.get(self._build_url(prompt), params=params)
         response.raise_for_status()
         content_type = response.headers.get("content-type", "")
+
+        if not content_type:
+            logging.warning(
+                "API returned empty content-type, attempting to process as image anyway"
+            )
+        elif not content_type.startswith("image/"):
+            logging.error("API returned non-image content: %s", response.text)
+            raise RuntimeError("API returned non-image content.")
+
         try:
-            if content_type.startswith("image/") or not content_type:
-                if not content_type:
-                    logging.warning(
-                        "API returned empty content-type, attempting to process as image anyway"
-                    )
-                try:
-                    image = PILImage.open(BytesIO(response.content))
-                except UnidentifiedImageError:
-                    logging.error("Failed to process response content as an image")
-                    raise RuntimeError(
-                        "Content could not be processed as an image."
-                    )
-            else:
-                logging.error("API returned non-image content: %s", response.text)
-                raise RuntimeError("API returned non-image content.")
+            image = PILImage.open(BytesIO(response.content))
+        except UnidentifiedImageError:
+            logging.error("Failed to process response content as an image")
+            raise RuntimeError("Content could not be processed as an image.")
         except OSError as e:
             raise RuntimeError(f"Failed to decode image: {e}") from e
         if save and file:

--- a/pollinations/image.py
+++ b/pollinations/image.py
@@ -95,11 +95,17 @@ class Image:
                     logging.warning(
                         "API returned empty content-type, attempting to process as image anyway"
                     )
-                image = PILImage.open(BytesIO(response.content))
+                try:
+                    image = PILImage.open(BytesIO(response.content))
+                except UnidentifiedImageError:
+                    logging.error("Failed to process response content as an image")
+                    raise RuntimeError(
+                        "Content could not be processed as an image."
+                    )
             else:
                 logging.error("API returned non-image content: %s", response.text)
                 raise RuntimeError("API returned non-image content.")
-        except (UnidentifiedImageError, OSError) as e:
+        except OSError as e:
             raise RuntimeError(f"Failed to decode image: {e}") from e
         if save and file:
             try:

--- a/pollinations/image.py
+++ b/pollinations/image.py
@@ -88,18 +88,13 @@ class Image:
         params.update(kwargs)
         response = self._sync_client.get(self._build_url(prompt), params=params)
         response.raise_for_status()
-        content_type = response.headers.get('content-type', '')
+        content_type = response.headers.get("content-type", "")
         try:
-            if content_type.startswith('image/') or not content_type:
+            if content_type.startswith("image/") or not content_type:
                 if not content_type:
-                    logging.warning("API returned empty content-type, attempting to process as image anyway")
-                image = PILImage.open(BytesIO(response.content))
-                logging.warning("API returned empty content-type, attempting to process as image anyway")
-                image = PILImage.open(BytesIO(response.content))
-            elif content_type.startswith('image/'):
-            if content_type.startswith('image/') or not content_type:
-                if not content_type:
-                    logging.warning("API returned empty content-type, attempting to process as image anyway")
+                    logging.warning(
+                        "API returned empty content-type, attempting to process as image anyway"
+                    )
                 image = PILImage.open(BytesIO(response.content))
             else:
                 logging.error("API returned non-image content: %s", response.text)


### PR DESCRIPTION
### **User description**
## Summary
- simplify content-type checks in `pollinations.image.Image`
- handle empty content-type responses without raising errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a7d547c488323806ab52d96de136c


___

### **PR Type**
Bug fix


___

### **Description**
- Fix duplicate code and indentation errors in image processing

- Improve content-type handling for empty responses

- Clean up logging and error handling logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Response"] --> B["Check content-type"]
  B --> C["image/* or empty"]
  B --> D["non-image content"]
  C --> E["Process as image"]
  D --> F["Log error & raise exception"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>image.py</strong><dd><code>Fix duplicate code and content-type handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pollinations/image.py

<ul><li>Remove duplicate code blocks and fix indentation<br> <li> Standardize quote usage from single to double quotes<br> <li> Clean up redundant image processing logic<br> <li> Improve warning message formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/DaFum/Wochenplan/pull/27/files#diff-e567be505726f720be1e048200cc4e53ea1ece9d1d457466d4bf6a9010895a1d">+5/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

